### PR TITLE
Expose css from graphiql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-error.log*
 dist/
 /graphiqlWithExtensions.js
 /graphiqlWithExtensions.min.js
+/graphiqlWithExtensions.css
 
 .merlin
 lib/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dist",
     "graphiqlWithExtensions.js",
     "graphiqlWithExtensions.min.js",
+    "graphiqlWithExtensions.css",
     "README.md",
     "LICENSE"
   ],

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -14,6 +14,8 @@ echo "Bundling graphiqlWithExtensions.js..."
 browserify -g browserify-shim -s GraphiQLWithExtensions dist/index.js > graphiqlWithExtensions.js
 echo "Bundling graphiqlWithExtensions.min.js..."
 browserify -g browserify-shim -t uglifyify -s GraphiQLWithExtensions dist/index.js | uglifyjs -c > graphiqlWithExtensions.min.js
+echo "Expose original css from GraphiQL(graphiql.css)"
+cp node_modules/graphiql/graphiql.css ./graphiqlWithExtensions.css
 # echo "Bundling graphiql.css..."
 # postcss --no-map --use autoprefixer -d dist/ css/*.css
 # cat dist/*.css > graphiql.css


### PR DESCRIPTION
Currently to change graphiql to this package you have to depend on css from original graphiql. In our case it is like this:
```
        <link href="https://cdn.jsdelivr.net/npm/graphiql@0.13.0/graphiql.css"
          rel="stylesheet"
          crossorigin="anonymous"/>
    <script src="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.2/graphiqlWithExtensions.min.js"
            crossorigin="anonymous"></script>
```
I would love to get rid of dependenci of original package and just use it like this
```
        <link href="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.2/graphiqlWithExtensions.css"
          rel="stylesheet"
          crossorigin="anonymous"/>
    <script src="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.2/graphiqlWithExtensions.min.js"
            crossorigin="anonymous"></script>
```

So this PR just expose css from original package.